### PR TITLE
Fix discord presence not able to detect virtualbox in vitrualbox v7.0.10

### DIFF
--- a/assets.json
+++ b/assets.json
@@ -66,8 +66,8 @@
                     "image": "windows_10",
                     "name": "Windows 10"
                 },
-				"Windows11": {
-                    "image": "windows_11",
+		"Windows11": {
+                    "image": "windows_10",
                     "name": "Windows 11"
                 },
                 "Windows2016": {

--- a/assets.json
+++ b/assets.json
@@ -66,6 +66,10 @@
                     "image": "windows_10",
                     "name": "Windows 10"
                 },
+				"Windows11": {
+                    "image": "windows_11",
+                    "name": "Windows 11"
+                },
                 "Windows2016": {
                     "image": "windows_2016",
                     "name": "Windows 2016"


### PR DESCRIPTION
Hi bukanspot,

When I tried to install this repo discord rich presence for the first time and run along with my Virtualbox 7.0.10, The discord rich presence stuck at "In Menu" despite the machine is still running. So I decide to explore and fix the code so It can run correctly (for now) on Virtualbox 7.0.10. Below are what I have modified: 

1/ For some reason Virtualbox gives state "Paused" eventhough the machine is running, so I added a workaround by putting "Paused" state in same condition with "FirstOnline".

2/ For the machine_list part, I just put the variable so it correctly get the value instead it gettings wrong/missing value of the machine.

3/ I added window 11 in assets.json, however because the server of the "client_id" doesn't have the windows_11 yet so I temporary put windows_10.

One more note is I have tried to run Discord Rich Presence on the [original repo](https://github.com/vidhanio/virtualbox-rich-presence), it appears this original repo still works on old Virtualbox like version 6.1.44.  By applying these modifies on our current repo, I think it may not work for older version of Virtualbox and its SDK.

Could you take a look at them?
Thank you.